### PR TITLE
Fix target os to macos. Add missing imports.

### DIFF
--- a/src/connectivity/providers/mod.rs
+++ b/src/connectivity/providers/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(target_os = "linux")]
 mod linux;
-#[cfg(target_os = "osx")]
+#[cfg(target_os = "macos")]
 mod osx;
 #[cfg(target_os = "windows")]
 mod windows;

--- a/src/connectivity/providers/osx.rs
+++ b/src/connectivity/providers/osx.rs
@@ -17,10 +17,7 @@ impl Connectivity for WiFi {
             .output()
             .map_err(|err| WifiConnectionError::FailedToConnect(format!("{}", err)))?;
 
-        if !String::from_utf8_lossy(&output.stdout)
-            .as_ref()
-            .contains("successfully activated")
-        {
+        if String::from_utf8_lossy(&output.stdout).as_ref() != "" {
             return Ok(false);
         }
 

--- a/src/hotspot/providers/mod.rs
+++ b/src/hotspot/providers/mod.rs
@@ -4,13 +4,13 @@ mod windows;
 #[cfg(target_os = "linux")]
 mod linux;
 
-#[cfg(target_os = "osx")]
+#[cfg(target_os = "macos")]
 mod osx;
 
 pub mod prelude {
   #[cfg(target_os = "linux")]
   pub use super::linux::*;
-  #[cfg(target_os = "osx")]
+  #[cfg(target_os = "macos")]
   pub use super::osx::*;
   #[cfg(target_os = "windows")]
   pub use super::windows::*;

--- a/src/hotspot/providers/osx.rs
+++ b/src/hotspot/providers/osx.rs
@@ -1,3 +1,4 @@
+use hotspot::{WifiHotspot, WifiHotspotError};
 use connectivity::{Connectivity, WifiConnectionError};
 use platforms::WiFi;
 use std::process::Command;

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -1,13 +1,13 @@
 #[cfg(target_os = "linux")]
 mod linux;
-#[cfg(target_os = "osx")]
+#[cfg(target_os = "macos")]
 mod osx;
 #[cfg(target_os = "windows")]
 mod windows;
 
 #[cfg(target_os = "linux")]
 pub use self::linux::{Connection, Linux as WiFi};
-#[cfg(target_os = "osx")]
+#[cfg(target_os = "macos")]
 pub use self::osx::{Connection, Osx as WiFi};
 #[cfg(target_os = "windows")]
 pub use self::windows::{Connection, Windows as WiFi};

--- a/src/platforms/osx.rs
+++ b/src/platforms/osx.rs
@@ -1,4 +1,4 @@
-use platforms::{WifiError, WifiInterface};
+use platforms::{Config, WifiError, WifiInterface};
 use std::process::Command;
 
 #[derive(Debug)]
@@ -14,7 +14,7 @@ pub struct Osx {
 }
 
 impl Osx {
-    pub fn new(name: &str, config: Option<Config>) -> Self {
+    pub fn new(config: Option<Config>) -> Self {
         Osx {
             connection: None,
             interface: config.map_or("en0".to_string(), |cfg| {


### PR DESCRIPTION
Fix target os to macos. 
Add missing imports.
Fix condition for Mac's stdout for successful connect for `networksetup -setairportnetwork`.