### PR TITLE
Fix Windows wrong output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), WifiConnectionError> {
             if result == true {
                 "Connection Successfull."
             } else {
-                "Invalid password."
+                "Invalid ssid or password."
             }
         ),
         Err(err) => println!("The following error occurred: {:?}", err),


### PR DESCRIPTION
Due to the fact that netsh output is based on the system's language settings, simply using "completed successfully" to check the result will not work in other languages

https://github.com/toksdotdev/wifi-rs/blob/c46c05d095710ca9f062efecade698e8feac84a5/src/connectivity/providers/windows.rs#L50-L52

To address this issue while keeping the solution simple, I use the user-provided ssid to match the output of 
`netsh wlan show interfaces`

I've also added a check to see if the system is already connected to the specified WLAN